### PR TITLE
Fix bug with creating a secure server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,6 @@
 # Project-specific files
 config.json
 
-# Certificate-specific files
-*.cert
-*.cer
-*.crt
-*.cet
-*.pfx
-
 # Godot 4+ specific ignores
 .godot/
 


### PR DESCRIPTION
Only the pfx file is needed. After creating the file, a new certificate needs to be created from the exported bytes. I don't entirely know why, but various search results lead me to that solution.