### PR TITLE
Switch to websockets

### DIFF
--- a/Scripts/Access Token/AccessToken.cs
+++ b/Scripts/Access Token/AccessToken.cs
@@ -7,10 +7,10 @@
         protected string AccessTokenString;
         protected int ExpiresIn;
 
-        protected DateTime CreationDate = DateTime.Now;
+        protected DateTime LastRefreshDate = DateTime.Now;
         protected int ExpirationBufferMillis = 1000;
 
-        public bool IsAboutToExpire => (DateTime.Now - CreationDate).TotalMilliseconds + ExpirationBufferMillis > ExpiresIn;
+        public bool IsAboutToExpire => (DateTime.Now - LastRefreshDate).TotalMilliseconds + ExpirationBufferMillis > ExpiresIn;
 
         public AccessToken(string accessToken, int expiresIn) {
             AccessTokenString = accessToken;

--- a/Scripts/Access Token/AppAccessToken.cs
+++ b/Scripts/Access Token/AppAccessToken.cs
@@ -14,7 +14,7 @@
                 return false;
             }
 
-            CreationDate = appAccessToken.CreationDate;
+            LastRefreshDate = appAccessToken.LastRefreshDate;
             AccessTokenString = appAccessToken.AccessTokenString;
             ExpiresIn = appAccessToken.ExpiresIn;
             return true;

--- a/Scripts/Access Token/UserAccessToken.cs
+++ b/Scripts/Access Token/UserAccessToken.cs
@@ -1,14 +1,40 @@
 ﻿namespace StoneBot.Scripts.Access_Token {
+    using App_Cache;
+    using Godot;
     using Models;
+    using System;
     using System.Threading.Tasks;
 
     internal class UserAccessToken : AccessToken {
-        private readonly string RefreshToken;
+        private string RefreshToken;
 
         public UserAccessToken(UserAccessTokenData data) : base(data.AccessToken, data.ExpiresIn) => RefreshToken = data.RefreshToken;
 
-        public override async Task<bool> Refresh() =>
-            // TODO
-            false;
+        public override async Task<bool> Refresh() {
+            var potentialConfigValues = await AppCache.ConfigValues.Get();
+            if (potentialConfigValues is null) {
+                GD.PushWarning("Cannot refresh user access token because configValues is null.");
+                return false;
+            }
+
+            var configValues = (ConfigValues)potentialConfigValues;
+            var potentialEserAccessTokenData = await Util.ProcessHttpResponseMessage<UserAccessTokenData>(await TwitchAPI.RefreshAccessToken(
+                new(),
+                configValues.BotClientId,
+                configValues.BotClientSecret,
+                RefreshToken
+            ));
+            if (potentialEserAccessTokenData is null) {
+                GD.PushWarning("Cannot refresh user access token because ProcessHttpResponseMessage failed.");
+                return false;
+            }
+
+            var userAccessTokenData = (UserAccessTokenData)potentialEserAccessTokenData;
+            LastRefreshDate = DateTime.Now;
+            AccessTokenString = userAccessTokenData.AccessToken;
+            ExpiresIn = userAccessTokenData.ExpiresIn;
+            RefreshToken = userAccessTokenData.RefreshToken;
+            return true;
+        }
     }
 }

--- a/Scripts/App Cache/AppCache.cs
+++ b/Scripts/App Cache/AppCache.cs
@@ -1,5 +1,6 @@
 ﻿namespace StoneBot.Scripts.App_Cache {
     using Access_Token;
+    using Http;
     using Http.Access_Token_Client;
     using Models;
     using System;
@@ -71,7 +72,9 @@
         public static CacheRValue<UserAccessToken> UserAccessToken = new(ValueGetters.GetUserAccessToken, null);
         public static CacheRValue<HttpAppAccessTokenClient> HttpAppAccessTokenClient = new(ValueGetters.GetHttpAppAccessTokenClient, null);
         public static CacheRValue<HttpUserAccessTokenClient> HttpUserAccessTokenClient = new(ValueGetters.GetHttpUserAccessTokenClient, null);
-        
+        public static CacheRValue<string> BroadcasterId = new(ValueGetters.GetBroadcasterId, null);
+        public static CacheRValue<EventSubWebSocketClient> EventSubWebSocketClient = new(ValueGetters.GetEventSubWebSocketClient, null);
+
         // TODO: store some cached values to disk on close, and load them on startup
     }
 }

--- a/Scripts/App Cache/Value Getters/AuthorizationCode.cs
+++ b/Scripts/App Cache/Value Getters/AuthorizationCode.cs
@@ -84,14 +84,14 @@
 
         private static bool HandleAuthorizationServerRequest(TcpServer.HttpRequestHandlerArgs args, TaskCompletionSource<string?> promise, string state) {
             string? parsedCode = null;
-            if (ValidateAuthorizationState(args.Request.URI, state)) {
-                parsedCode = GetAuthorizationCodeFromURI(args.Request.URI);
+            if (ValidateAuthorizationState(args.Request.Uri, state)) {
+                parsedCode = GetAuthorizationCodeFromUri(args.Request.Uri);
                 if (parsedCode is null) {
-                    GD.PushWarning("Cannot get authorization code because authorization code could not be parsed from request URI.");
+                    GD.PushWarning("Cannot get authorization code because authorization code could not be parsed from request uri.");
                     args.Response = new() {
                         StatusCode = 400,
                         ReasonPhrase = "Bad Request",
-                        Message = "<html><head><title>Authorization Failed</title></head><body><h1>:(</h1><p>Cannot get authorization code because authorization code could not be parsed from request URI.</p></body></html>"
+                        Message = "<html><head><title>Authorization Failed</title></head><body><h1>:(</h1><p>Cannot get authorization code because authorization code could not be parsed from request uri.</p></body></html>"
                     };
                 } else {
                     args.Response.Message = "<html><head><title>Authorization Succeeded</title></head><body><h1>Authorization Success! :)</h1><p>You can close this tab.</p></body></html>";
@@ -129,7 +129,7 @@
             return match.Groups[1].Value == state;
         }
 
-        private static string? GetAuthorizationCodeFromURI(string uri) {
+        private static string? GetAuthorizationCodeFromUri(string uri) {
             var codeRegex = new Regex("code=([a-zA-Z0-9]*)");
             var match = codeRegex.Match(uri);
             if (!match.Success) {

--- a/Scripts/App Cache/Value Getters/BroadcasterId.cs
+++ b/Scripts/App Cache/Value Getters/BroadcasterId.cs
@@ -1,43 +1,42 @@
-﻿namespace StoneBot.Scripts.Middleware {
-    using App_Cache;
+﻿namespace StoneBot.Scripts.App_Cache.Value_Getters {
     using Godot;
     using Models;
     using System.Threading.Tasks;
 
-    internal static class Broadcaster {
-        public static async Task<UserData?> GetBroadcasterData() {
+    internal static partial class ValueGetters {
+        public static async Task<string?> GetBroadcasterId() {
             var potentialConfigValues = await AppCache.ConfigValues.Get();
             if (potentialConfigValues is null) {
-                GD.PushWarning("Cannot get broadcaster data because configValues is null.");
+                GD.PushWarning("Cannot get broadcaster id because configValues is null.");
                 return null;
             }
 
             var configValues = (ConfigValues)potentialConfigValues;
             var httpUserAccessTokenClient = await AppCache.HttpUserAccessTokenClient.Get();
             if (httpUserAccessTokenClient is null) {
-                GD.PushWarning("Cannot get broadcaster data because httpUserAccessTokenClient is null.");
+                GD.PushWarning("Cannot get broadcaster id because httpUserAccessTokenClient is null.");
                 return null;
             }
 
             var client = await httpUserAccessTokenClient.GetClient();
             if (client is null) {
-                GD.PushWarning("Cannot get broadcaster data because httpUserAccessTokenClient.GetClient failed.");
+                GD.PushWarning("Cannot get broadcaster id because httpUserAccessTokenClient.GetClient failed.");
                 return null;
             }
 
             var potentialUsersData = await Util.ProcessHttpResponseMessage<UsersData>(await TwitchAPI.GetUsers(client, null, new[] { configValues.BroadcasterLogin }));
             if (potentialUsersData is null) {
-                GD.PushWarning("Cannot get broadcaster data because ProcessHttpResponseMessage failed.");
+                GD.PushWarning("Cannot get broadcaster id because ProcessHttpResponseMessage failed.");
                 return null;
             }
 
             var usersData = (UsersData)potentialUsersData;
             if (usersData.Data.Length == 0) {
-                GD.PushWarning($"Cannot get broadcaster data because GetUsers found no users.");
+                GD.PushWarning($"Cannot get broadcaster id because GetUsers found no users.");
                 return null;
             }
 
-            return usersData.Data[0];
+            return usersData.Data[0].Id;
         }
     }
 }

--- a/Scripts/App Cache/Value Getters/EventSubWebSocketClient.cs
+++ b/Scripts/App Cache/Value Getters/EventSubWebSocketClient.cs
@@ -1,0 +1,17 @@
+﻿namespace StoneBot.Scripts.App_Cache.Value_Getters {
+    using Godot;
+    using Http;
+    using System.Threading.Tasks;
+
+    internal static partial class ValueGetters {
+        public static async Task<EventSubWebSocketClient?> GetEventSubWebSocketClient() {
+            var eventSubWebSocketClient = await EventSubWebSocketClient.Create();
+            if (eventSubWebSocketClient is null) {
+                GD.PushWarning("Cannot get event sub web socket client because creation failed.");
+                return null;
+            }
+
+            return eventSubWebSocketClient;
+        }
+    }
+}

--- a/Scripts/App.cs
+++ b/Scripts/App.cs
@@ -8,16 +8,25 @@
         public App() => _ = Task.Run(Init);
 
         public async Task<bool> Init() {
-            var potentialEventSubs = await EventSub.Get<IConditionData>();
+            _ = await PrintEventSubs();
+            _ = await EventSub.RemoveBy();
+            _ = await PrintEventSubs();
+            _ = await ChannelChatMessage.Connect();
+            _ = await PrintEventSubs();
+            return true;
+        }
+
+        private static async Task<bool> PrintEventSubs() {
+            var potentialEventSubs = await EventSub.Get();
             if (potentialEventSubs is null) {
-                GD.PushWarning("Cannot init app because Get failed.");
+                GD.PushWarning("Cannot print event subs because Get failed.");
                 return false;
             }
 
-            var eventSubs = (EventSubsData<IConditionData>)potentialEventSubs;
+            var eventSubs = (EventSubsData)potentialEventSubs;
             GD.Print($"EventSubs: {eventSubs.Data.Length}");
             foreach (var eventSub in eventSubs.Data) {
-                GD.Print($"EventSub: {eventSub.Id}");
+                GD.Print($"EventSub: {{{eventSub.Id}, {eventSub.Status}}}");
             }
 
             return true;

--- a/Scripts/Http/EventSubWebSocketClient.cs
+++ b/Scripts/Http/EventSubWebSocketClient.cs
@@ -1,0 +1,68 @@
+﻿namespace StoneBot.Scripts.Http {
+    using Godot;
+    using Models.EventSub_Message;
+    using System;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using static WebSocketClient;
+
+    internal class EventSubWebSocketClient {
+        public string Id { get; private set; } = null!;
+
+        private WebSocketClient Client = null!;
+
+        // TODO: reconnect when keepalive_timeout_seconds is up
+
+        private EventSubWebSocketClient() { }
+
+        public static async Task<EventSubWebSocketClient?> Create() {
+            var eventSubWebSocketClient = new EventSubWebSocketClient();
+            var getIdPromise = new TaskCompletionSource<bool>();
+            var setIdFromRequest = GetSetIdFromRequest(eventSubWebSocketClient, getIdPromise);
+            eventSubWebSocketClient.Client = new();
+            eventSubWebSocketClient.Client.RequestHandler += setIdFromRequest;
+            if (!await eventSubWebSocketClient.Client.Start("wss://eventsub.wss.twitch.tv/ws")) {
+                GD.PushWarning("Cannot create EventSubWebSocketClient because Client.Start failed.");
+                return null;
+            }
+
+            var success = await getIdPromise.Task;
+            eventSubWebSocketClient.Client.RequestHandler -= setIdFromRequest;
+            if (!success) {
+                GD.PushWarning("Cannot create EventSubWebSocketClient because setIdFromRequest failed.");
+                if (!await eventSubWebSocketClient.Client.Stop()) {
+                    GD.PushError("EventSubWebSocketClient stop failed.");
+                }
+
+                return null;
+            }
+
+            eventSubWebSocketClient.Client.RequestHandler += eventSubWebSocketClient.HandleRequest;
+
+            return eventSubWebSocketClient;
+        }
+
+        private static WebSocketRequestHandler GetSetIdFromRequest(EventSubWebSocketClient eventSubWebSocketClient, TaskCompletionSource<bool> promise) => (object sender, string request) => {
+            EventSubWelcomeMessage welcomeMessage;
+            try {
+                welcomeMessage = JsonSerializer.Deserialize<EventSubWelcomeMessage>(request);
+            } catch (Exception e) {
+                GD.PushWarning($"Could not parse request: {e}.");
+                if (!promise.TrySetResult(false)) {
+                    GD.PushError("Could not resolve promise.");
+                }
+
+                return;
+            }
+
+            eventSubWebSocketClient.Id = welcomeMessage.Payload.Session.Id;
+            if (!promise.TrySetResult(true)) {
+                GD.PushError("Could not resolve promise.");
+            }
+        };
+
+        private void HandleRequest(object sender, string request) =>
+            // TODO
+            GD.Print(request);
+    }
+}

--- a/Scripts/Http/HttpRequest.cs
+++ b/Scripts/Http/HttpRequest.cs
@@ -18,10 +18,10 @@
         }
 
         public RequestMethod Method;
-        public string URI = null!;
+        public string Uri = null!;
 
         public static async Task<HttpRequest?> FromStream(Stream stream) {
-            var buffer = new byte[65536];
+            var buffer = new byte[1024];
 
             int numBytesRead;
             try {
@@ -49,11 +49,9 @@
                 return null;
             }
 
-            HttpRequest request;
-            try {
-                request = Parse(requestString);
-            } catch (Exception e) {
-                GD.PushWarning($"Could not get string from client stream bytes: {e}.");
+            var request = Parse(requestString);
+            if (request is null) {
+                GD.PushWarning($"Cannot parse http request because Parse failed.");
                 return null;
             }
 
@@ -76,7 +74,7 @@
             }
 
             result.Method = GetMethod(requestLineParts[0]);
-            result.URI = requestLineParts[1];
+            result.Uri = requestLineParts[1];
 
             if (requestLineParts[2] != "HTTP/1.1") {
                 GD.PushWarning($"Cannot parse request string because protocol version '{requestLineParts[2]}' is not supported.");

--- a/Scripts/Http/TcpServer.cs
+++ b/Scripts/Http/TcpServer.cs
@@ -1,7 +1,5 @@
 ﻿namespace StoneBot.Scripts.Http {
-    using App_Cache;
     using Godot;
-    using Models;
     using System;
     using System.Net;
     using System.Net.Sockets;
@@ -61,31 +59,15 @@
         }
 
         private void StartListening() => Task.Run(async () => {
-            var potentialConfigValues = await AppCache.ConfigValues.Get();
-            if (potentialConfigValues is null) {
-                GD.PushWarning("Cannot start listening because configValues is null.");
-                return;
-            }
-
-            var configValues = (ConfigValues)potentialConfigValues;
-            var tries = 0;
             while (IsRunning) {
-                if (tries > configValues.ServerMaxRetries) {
-                    GD.PushWarning("Cannot accept client because max retries is reached.");
-                    _ = Stop();
-                    return;
-                }
-
                 TcpClient client;
                 try {
                     client = await Server.AcceptTcpClientAsync();
                 } catch (Exception e) {
                     GD.PushWarning($"Could not accept client: {e}.");
-                    tries++;
-                    continue;
+                    return;
                 }
 
-                tries = 0;
                 var response = new HttpResponse();
                 try {
                     using var clientStream = client.GetStream();

--- a/Scripts/Http/WebSocketClient.cs
+++ b/Scripts/Http/WebSocketClient.cs
@@ -1,0 +1,92 @@
+﻿namespace StoneBot.Scripts.Http {
+    using Godot;
+    using System;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    internal class WebSocketClient {
+        public delegate void WebSocketRequestHandler(object sender, string request);
+        public event WebSocketRequestHandler RequestHandler = delegate { };
+
+        private readonly ClientWebSocket WebSocket = new();
+
+        public bool IsRunning { get; private set; } = false;
+
+        public async Task<bool> Start(string uriString) {
+            if (IsRunning) {
+                GD.PushWarning($"Cannot start server because server is already running.");
+                return false;
+            }
+
+            Uri uri;
+            try {
+                uri = new(uriString);
+            } catch (Exception e) {
+                GD.PushWarning($"Could not create uri from uri string: {e}.");
+                return false;
+            }
+
+            try {
+                await WebSocket.ConnectAsync(uri, default);
+            } catch (Exception e) {
+                GD.PushWarning($"Could not start server: {e}.");
+                return false;
+            }
+
+            IsRunning = true;
+            StartListening();
+
+            return true;
+        }
+
+        public async Task<bool> Stop(WebSocketCloseStatus closeStatus = WebSocketCloseStatus.NormalClosure, string statusDescription = "Client Closed") {
+            if (!IsRunning) {
+                GD.PushWarning($"Cannot stop server because server is not running.");
+                return false;
+            }
+
+            try {
+                await WebSocket.CloseAsync(closeStatus, statusDescription, default);
+            } catch (Exception e) {
+                GD.PushWarning($"Could not stop server: {e}.");
+                return false;
+            }
+
+            IsRunning = false;
+            return true;
+        }
+
+        private void StartListening() => Task.Run(async () => {
+            while (IsRunning) {
+                var resultBytes = new byte[1024];
+                WebSocketReceiveResult result;
+                try {
+                    result = await WebSocket.ReceiveAsync(resultBytes, default);
+                } catch (Exception e) {
+                    GD.PushWarning($"Could not receive from web socket: {e}.");
+                    continue;
+                }
+
+                if (result.CloseStatus is not null) {
+                    GD.PushWarning($"WebSocketClient closed by server: {result.CloseStatus}: {result.CloseStatusDescription ?? "no description"}.");
+                    if (!await Stop()) {
+                        GD.PushError("WebSocketClient stop failed.");
+                    }
+
+                    return;
+                }
+
+                string request;
+                try {
+                    request = Encoding.Default.GetString(resultBytes, 0, result.Count);
+                } catch (Exception e) {
+                    GD.PushWarning($"Could not get string from result bytes: {e}.");
+                    return;
+                }
+
+                RequestHandler.Invoke(this, request);
+            }
+        });
+    }
+}

--- a/Scripts/Middleware/EventSub/ChannelChatMessage.cs
+++ b/Scripts/Middleware/EventSub/ChannelChatMessage.cs
@@ -1,9 +1,53 @@
 ﻿namespace StoneBot.Scripts.Middleware.EventSub {
+    using App_Cache;
+    using Godot;
+    using Models;
     using System.Threading.Tasks;
 
     internal static class ChannelChatMessage {
-        public static async Task<bool> Connect() =>
-            // TODO
-            false;
+        public static async Task<bool> Connect() {
+            var potentialConfigValues = await AppCache.ConfigValues.Get();
+            if (potentialConfigValues is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because configValues is null.");
+                return false;
+            }
+
+            var httpUserAccessTokenClient = await AppCache.HttpUserAccessTokenClient.Get();
+            if (httpUserAccessTokenClient is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because httpUserAccessTokenClient is null.");
+                return false;
+            }
+
+            var broadcasterId = await AppCache.BroadcasterId.Get();
+            if (broadcasterId is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because broadcasterId is null.");
+                return false;
+            }
+
+            var eventSubWebSocketClient = await AppCache.EventSubWebSocketClient.Get();
+            if (eventSubWebSocketClient is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because eventSubWebSocketClient is null.");
+                return false;
+            }
+
+            var client = await httpUserAccessTokenClient.GetClient();
+            if (client is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because httpUserAccessTokenClient.GetClient failed.");
+                return false;
+            }
+
+            var eventSubData = await Util.ProcessHttpResponseMessage<EventSubData>(await TwitchAPI.ChannelChatMessageEventSub(
+                client,
+                broadcasterId,
+                broadcasterId,
+                eventSubWebSocketClient.Id
+            ));
+            if (eventSubData is null) {
+                GD.PushWarning("Cannot connect channel chat message event sub because ProcessHttpResponseMessage failed.");
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Scripts/Models/ConfigValues.cs
+++ b/Scripts/Models/ConfigValues.cs
@@ -2,8 +2,6 @@
     using System.Text.Json.Serialization;
 
     public struct ConfigValues {
-        [JsonPropertyName("serverMaxRetries")]
-        public int ServerMaxRetries { get; set; }
         [JsonPropertyName("authorizationPort")]
         public int AuthorizationPort { get; set; }
         [JsonPropertyName("botClientId")]

--- a/Scripts/Models/EventSub Message/EventSubMessage.cs
+++ b/Scripts/Models/EventSub Message/EventSubMessage.cs
@@ -1,0 +1,16 @@
+﻿namespace StoneBot.Scripts.Models.EventSub_Message {
+    using System.Text.Json.Serialization;
+
+    public struct EventSubSessionData {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+        [JsonPropertyName("connected_at")]
+        public string ConnectedAt { get; set; }
+        [JsonPropertyName("keepalive_timeout_seconds")]
+        public int KeepaliveTimeoutSeconds { get; set; }
+        [JsonPropertyName("reconnect_url")]
+        public string? ReconnectUrl { get; set; }
+    }
+}

--- a/Scripts/Models/EventSub Message/Welcome.cs
+++ b/Scripts/Models/EventSub Message/Welcome.cs
@@ -1,0 +1,24 @@
+﻿namespace StoneBot.Scripts.Models.EventSub_Message {
+    using System.Text.Json.Serialization;
+
+    public struct EventSubWelcomeMessageMetadata {
+        [JsonPropertyName("message_id")]
+        public string MessageId { get; set; }
+        [JsonPropertyName("message_type")]
+        public string MessageType { get; set; }
+        [JsonPropertyName("message_timestamp")]
+        public string MessageTimestamp { get; set; }
+    }
+
+    public struct EventSubWelcomeMessagePayload {
+        [JsonPropertyName("session")]
+        public EventSubSessionData Session { get; set; }
+    }
+
+    public struct EventSubWelcomeMessage {
+        [JsonPropertyName("metadata")]
+        public EventSubWelcomeMessageMetadata Metadata { get; set; }
+        [JsonPropertyName("payload")]
+        public EventSubWelcomeMessagePayload Payload { get; set; }
+    }
+}

--- a/Scripts/Models/GetEventSubs.cs
+++ b/Scripts/Models/GetEventSubs.cs
@@ -1,7 +1,6 @@
 ﻿namespace StoneBot.Scripts.Models {
+    using System.Text.Json;
     using System.Text.Json.Serialization;
-
-    public interface IConditionData { }
 
     public struct TransportData {
         [JsonPropertyName("method")]
@@ -14,7 +13,7 @@
         public string DisconnectedAt { get; set; }
     }
 
-    public struct EventSubData<TConditionData> where TConditionData : IConditionData {
+    public struct EventSubData {
         [JsonPropertyName("id")]
         public string Id { get; set; }
         [JsonPropertyName("status")]
@@ -24,7 +23,7 @@
         [JsonPropertyName("version")]
         public string Version { get; set; }
         [JsonPropertyName("condition")]
-        public TConditionData Condition { get; set; }
+        public JsonElement Condition { get; set; }
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; set; }
         [JsonPropertyName("transport")]
@@ -38,9 +37,9 @@
         public string? Cursor { get; set; }
     }
 
-    public struct EventSubsData<TConditionData> where TConditionData : IConditionData {
+    public struct EventSubsData {
         [JsonPropertyName("data")]
-        public EventSubData<TConditionData>[] Data { get; set; }
+        public EventSubData[] Data { get; set; }
         [JsonPropertyName("total")]
         public int Total { get; set; }
         [JsonPropertyName("total_cost")]

--- a/Scripts/Util.cs
+++ b/Scripts/Util.cs
@@ -24,6 +24,24 @@
             return responseStruct;
         }
 
+        public static async Task<JsonDocument?> ProcessHttpResponseMessage(HttpResponseMessage? response) {
+            var responseString = await VerifyHttpResponseMessage(response);
+            if (responseString is null) {
+                GD.PushWarning("Could not process http response message because VerifyHttpResponseMessage failed.");
+                return null;
+            }
+
+            JsonDocument jsonDocument;
+            try {
+                jsonDocument = JsonDocument.Parse(responseString);
+            } catch (Exception e) {
+                GD.PushWarning($"Could not parse response json: {e}.");
+                return null;
+            }
+
+            return jsonDocument;
+        }
+
         public static async Task<string?> VerifyHttpResponseMessage(HttpResponseMessage? response) {
             if (response is null) {
                 GD.PushWarning("Cannot process http response message because request failed.");


### PR DESCRIPTION
Changed AccessToken.CreationDate to AccessToken.LastRefreshDate to be more accurate.

Defined UserAccessToken.Refresh()

Added BroadcasterId and EventSubWebSocketClient to AppCache.

Renamed URI to uri or Uri where appropriate.

Changed GetBroadcasterData() to GetBroadcasterId(). This may get changed back if other pieces of broadcaster data are needed.

Added EventSubWebSocketClient.

Lowered max bytes that HttpRequest can read (who really needs 65536 bytes anyway).

Removed http server retries. They were not really retries in the traditional sense, and it is unlikely that if it fails in that spot, it will continue to fail. There is no point in retrying.

Added WebSocketClient.

Defined ChannelChatMessage.Connect().

Changed some models to use JsonElements instead of generic typed structs.

Added another Util.ProcessHttpResponseMessage() to process responses whose type is variable or unknown.

A few bug fixes.