### PR TITLE
Handle reconnect request

### DIFF
--- a/Scripts/Bot Core/Twitch/EventSub.cs
+++ b/Scripts/Bot Core/Twitch/EventSub.cs
@@ -47,6 +47,16 @@
         }
 
         // collector access token
+        public static async Task<HttpResponseMessage?> AddEventSub<T>(HttpClient client, T content) {
+            try {
+                return await client.PostAsJsonAsync("https://api.twitch.tv/helix/eventsub/subscriptions", content);
+            } catch (Exception e) {
+                Logger.Warning($"Cannot add event sub because client.PostAsJsonAsync failed: {e}.");
+                return null;
+            }
+        }
+
+        // collector access token
         public static async Task<HttpResponseMessage?> SubscribeToChannelChatMessage(HttpClient client, string broadcasterUserId, string userId, string sessionId) {
             Logger.Info("Subscribing to channel chat message event sub on Twitch.");
             var content = new {
@@ -61,13 +71,7 @@
                     session_id = sessionId
                 }
             };
-
-            try {
-                return await client.PostAsJsonAsync("https://api.twitch.tv/helix/eventsub/subscriptions", content);
-            } catch (Exception e) {
-                Logger.Warning($"Cannot subscribe to channel chat message because client.PostAsJsonAsync failed: {e}.");
-                return null;
-            }
+            return await AddEventSub(client, content);
         }
     }
 }

--- a/Scripts/Core Interface/EventSub.cs
+++ b/Scripts/Core Interface/EventSub.cs
@@ -78,6 +78,17 @@
             return true;
         }
 
+        public static async Task<bool> Add(EventSubData eventSub) {
+            Logger.Info("Adding event sub.");
+            var clientWrapper = await AppCache.CollectorClientWrapper.Get();
+            if (clientWrapper is null) {
+                return false;
+            }
+
+            var client = await clientWrapper.GetClient();
+            return client is not null && await Util.GetMessageAs<EventSubData>(TwitchAPI.AddEventSub(client, eventSub)) is not null;
+        }
+
         public static async Task<bool> ConnectChannelChatMessage(Func<ChannelChatMessageEvent, Task> handler) {
             Logger.Info("Connecting to channel chat message event sub.");
             var config = await AppCache.Config.Get();
@@ -118,7 +129,7 @@
             var eventSubData = await Util.GetMessageAs<EventSubData>(TwitchAPI.SubscribeToChannelChatMessage(
                 client,
                 broadcaster.Id,
-                broadcaster.Id, // TODO: figure out why permission fails when this it bot.Id
+                broadcaster.Id,
                 sessionId
             ));
             if (eventSubData is null) {


### PR DESCRIPTION
Prevented websocket from creating new tasks for listening when automatically reconnecting.

Changed a log statement to use the correct logger.

Updated the reconnect handler to automatically reconnect to Twitch and resubscribe to all eventsubs.

Added helper methods for resubscribing eventsubs.

Removed TODO - The "proper" way to use that endpoint is to specify the bot's id so that the bot can read the chat from its own account. Meaning that if the bot's Twitch account was not setup to be a moderator, it would not be able to read the chat as a moderator. This would require a second authentication process for allowing the bot's account to read the broadcaster's chat. It makes much more sense to have the bot read the chat with the broadcaster's view, and if any restrictions are wanted, they should be implemented in the bot itself, not via the bot's Twitch account.