### PR TITLE
Fix get subscriber bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ Add a `config.json` file to the new folder with the contents:
   "authorizationPort": 6969,
   "chatterClientId": <your chatter application client id>,
   "chatterClientSecret": <your chatter application client secret>,
-  "chatterScope": [ "user:write:chat" ],
+  "chatterScope": ["user:write:chat", "user:read:chat"],
   "collectorClientId": <your collector application client id>,
   "collectorClientSecret": <your collector client secret>,
-  "collectorScope": [ "user:read:chat", "channel:read:vips", "channel:read:subscriptions", "moderation:read" ],
+  "collectorScope": [
+	"channel:read:vips",
+	"channel:read:subscriptions",
+	"moderation:read"
+  ],
   "socketKeepaliveBuffer": 5000,
   "socketKeepaliveTimeout": 10,
   "tokenExpirationBuffer": 1000

--- a/Scripts/Bot Core/App Cache/WebSocketClient.cs
+++ b/Scripts/Bot Core/App Cache/WebSocketClient.cs
@@ -1,7 +1,7 @@
 ﻿namespace Stonebot.Scripts.Bot_Core.App_Cache {
-    using Models.EventSub_Message;
-    using Models.EventSub;
     using Core_Interface.EventSub;
+    using Models.EventSub;
+    using Models.EventSub_Message;
     using System;
     using System.Collections.Generic;
     using System.Net.WebSockets;

--- a/Scripts/Bot Core/Models/Permission.cs
+++ b/Scripts/Bot Core/Models/Permission.cs
@@ -5,6 +5,6 @@
         [JsonPropertyName("data")]
         public SimpleUserData[] Data { get; set; }
         [JsonPropertyName("pagination")]
-        private PaginationData Pagination { get; set; }
+        public PaginationData Pagination { get; set; }
     }
 }

--- a/Scripts/Bot Core/Models/Subscription.cs
+++ b/Scripts/Bot Core/Models/Subscription.cs
@@ -1,21 +1,41 @@
 ﻿namespace Stonebot.Scripts.Bot_Core.Models {
     using System.Text.Json.Serialization;
 
-    internal struct SimpleSubscriptionData {
+    internal struct SubscriptionData {
         [JsonPropertyName("broadcaster_id")]
         public string BroadcasterId { get; set; }
-        [JsonPropertyName("broadcaster_name")]
-        public string BroadcasterName { get; set; }
         [JsonPropertyName("broadcaster_login")]
         public string BroadcasterLogin { get; set; }
+        [JsonPropertyName("broadcaster_name")]
+        public string BroadcasterName { get; set; }
+        [JsonPropertyName("gifter_id")]
+        public string GifterId { get; set; }
+        [JsonPropertyName("gifter_login")]
+        public string GifterLogin { get; set; }
+        [JsonPropertyName("gifter_name")]
+        public string GifterName { get; set; }
         [JsonPropertyName("is_gift")]
         public bool IsGift { get; set; }
+        [JsonPropertyName("plan_name")]
+        public string PlanName { get; set; }
         [JsonPropertyName("tier")]
         public string Tier { get; set; }
+        [JsonPropertyName("user_id")]
+        public string UserId { get; set; }
+        [JsonPropertyName("user_login")]
+        public string UserLogin { get; set; }
+        [JsonPropertyName("user_name")]
+        public string UserName { get; set; }
     }
 
-    internal struct SimpleSubscriptionsData {
+    internal struct PaginatedSubscriptionsData {
         [JsonPropertyName("data")]
-        public SimpleSubscriptionData[] Data { get; set; }
+        public SubscriptionData[] Data { get; set; }
+        [JsonPropertyName("pagination")]
+        public PaginationData Pagination { get; set; }
+        [JsonPropertyName("points")]
+        public int Points { get; set; }
+        [JsonPropertyName("total")]
+        public int Total { get; set; }
     }
 }

--- a/Scripts/Bot Core/Twitch/Auth.cs
+++ b/Scripts/Bot Core/Twitch/Auth.cs
@@ -12,7 +12,7 @@
 
             var process = new Process();
             process.StartInfo.UseShellExecute = true;
-            process.StartInfo.FileName = $"https://id.twitch.tv/oauth2/authorize?client_id={clientId}&force_verify={forceVerify}&redirect_uri={redirectUri}&response_type=code&scope={scopeParam}";
+            process.StartInfo.FileName = $"https://id.twitch.tv/oauth2/authorize?client_id={clientId}&force_verify={(forceVerify ? "true" : "false")}&redirect_uri={redirectUri}&response_type=code&scope={scopeParam}";
             if (state is not null) {
                 process.StartInfo.FileName += $"&state={state}";
             }
@@ -31,7 +31,7 @@
         public static async Task<HttpResponseMessage?> GetAccessToken(HttpClient client, string clientId, string clientSecret, string authorizationCode, string redirectUri) {
             Logger.Info("Getting access token from Twitch.");
             try {
-                return await client.PostAsync($"https://id.twitch.tv/oauth2/token?&client_id={clientId}&client_secret={clientSecret}&code={authorizationCode}&grant_type=authorization_code&redirect_uri={redirectUri}", null);
+                return await client.PostAsync($"https://id.twitch.tv/oauth2/token?client_id={clientId}&client_secret={clientSecret}&code={authorizationCode}&grant_type=authorization_code&redirect_uri={redirectUri}", null);
             } catch (Exception e) {
                 Logger.Warning($"Cannot get access token because client.PostAsync failed: {e}.");
                 return null;

--- a/Scripts/Core Interface/EventSub.cs
+++ b/Scripts/Core Interface/EventSub.cs
@@ -116,7 +116,7 @@
                 return false;
             }
 
-            var clientWrapper = await AppCache.CollectorClientWrapper.Get();
+            var clientWrapper = await AppCache.ChatterClientWrapper.Get();
             if (clientWrapper is null) {
                 return false;
             }
@@ -129,7 +129,7 @@
             var eventSubData = await Util.GetMessageAs<EventSubData>(TwitchAPI.SubscribeToChannelChatMessage(
                 client,
                 broadcaster.Id,
-                broadcaster.Id,
+                bot.Id,
                 sessionId
             ));
             if (eventSubData is null) {

--- a/Scripts/Core Interface/User.cs
+++ b/Scripts/Core Interface/User.cs
@@ -56,8 +56,8 @@
             return simpleUsersData is null ? null : ((PaginatedSimpleUsersData)simpleUsersData).Data.Length == 1;
         }
 
-        public static async Task<SimpleSubscriptionData?> CheckUserSubscriptions(string userId) {
-            Logger.Info("Checking user subscriptions.");
+        public static async Task<int?> GetSubTier(string userId) {
+            Logger.Info("Getting is user subscriber.");
             var broadcaster = await AppCache.Broadcaster.Get();
             if (broadcaster is null) {
                 return null;
@@ -73,17 +73,24 @@
                 return null;
             }
 
-            var potentialSubscriptionsData = await Util.GetMessageAs<SimpleSubscriptionsData>(TwitchAPI.CheckUserSubscription(
+            var potentialSubscriptionsData = await Util.GetMessageAs<PaginatedSubscriptionsData>(TwitchAPI.GetBroadcasterSubscriptions(
                 client,
                 broadcaster.Id,
-                userId
+                new[] { userId }
             ));
             if (potentialSubscriptionsData is null) {
                 return null;
             }
 
-            var subscriptionsData = (SimpleSubscriptionsData)potentialSubscriptionsData;
-            return subscriptionsData.Data.Length == 0 ? null : subscriptionsData.Data[0];
+            var subscriptionsData = (PaginatedSubscriptionsData)potentialSubscriptionsData;
+            return subscriptionsData.Data.Length == 0
+                ? null
+                : subscriptionsData.Data[0].Tier switch {
+                    "1000" => 1,
+                    "2000" => 2,
+                    "3000" => 3,
+                    _ => null,
+                };
         }
     }
 }

--- a/Scripts/Permission.cs
+++ b/Scripts/Permission.cs
@@ -1,6 +1,5 @@
 ﻿namespace Stonebot.Scripts {
     using Bot_Core.App_Cache;
-    using Bot_Core.Models;
     using System.Threading.Tasks;
     using static Core_Interface.User;
 
@@ -27,19 +26,18 @@
                 return PermissionLevel.Mod;
             }
 
-            var potentialSubData = await CheckUserSubscriptions(userId);
-            if (potentialSubData is not null) {
-                var tier = ((SimpleSubscriptionData)potentialSubData).Tier;
-                switch (tier) {
-                    case "1":
+            var subTier = await GetSubTier(userId);
+            if (subTier is not null) {
+                switch (subTier) {
+                    case 1:
                         return PermissionLevel.Tier1Sub;
-                    case "2":
+                    case 2:
                         return PermissionLevel.Tier2Sub;
-                    case "3":
+                    case 3:
                         return PermissionLevel.Tier3Sub;
                 }
 
-                Logger.Warning($"Cannot get highest because subscription tier '{tier}' is not supported.");
+                Logger.Warning($"Cannot get highest because subscription tier '{subTier}' is not supported.");
                 return null;
             }
 


### PR DESCRIPTION
Updated README.md to include the scope changes for the auth bug fix.

Minor cleanups.

Changed the method for getting a broadcaster's subscriptions to one that does not require a user's authorization.

Fixed a bug in the authorization process that would not require the user to authorize if they had previously authorized and were already logged in to Twitch. It is necessary to force the user to authorize because they would need to login to both the broadcaster account, and then the bot account.

Fixed a bug that caused chat messages to be read from the pov of the broadcaster rather than the pov of the bot's Twitch account.

NOTE: because the authorization scopes have been changed, follow the instructions in the readme to reauthorize