### PR TITLE
Make Scroll to Bottom Button Margin not Receive Mouse Input

### DIFF
--- a/Scenes/LogsTab.tscn
+++ b/Scenes/LogsTab.tscn
@@ -48,6 +48,7 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
+mouse_filter = 2
 theme_override_constants/margin_right = 13
 
 [node name="ScrollToBottomButton" type="Button" parent="ScrollToBottomMargin"]


### PR DESCRIPTION
Changed the mouse filter on the margin container of the "Scroll to Bottom" button so that it no longer prevents the scroll bar from receiving mouse inputs.