### PR TITLE
Make `!lurk` Command Use Chatter Name

### DIFF
--- a/Scripts/Command/UseActions.cs
+++ b/Scripts/Command/UseActions.cs
@@ -238,7 +238,7 @@
             _ = await Chat.Send($"catKISS {messageEvent.ChatterUserName} catKISS");
         }
 
-        public static async Task Lurk(ChannelChatMessageEvent messageEvent, PermissionLevel __) => _ = await Chat.Send($"{messageEvent.BroadcasterUserName}, thank you for your presence!");
+        public static async Task Lurk(ChannelChatMessageEvent messageEvent, PermissionLevel __) => _ = await Chat.Send($"{messageEvent.ChatterUserName}, thank you for your presence!");
 
         public static async Task Discord(ChannelChatMessageEvent messageEvent, PermissionLevel __) {
             var customData = await AppCache.Data.Get();

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Stonebot"
 config/description="A chatbot for Twitch"
-config/version="0.4.0"
+config/version="0.4.1"
 run/main_scene="res://Scenes/Main.tscn"
 config/features=PackedStringArray("4.4", "C#", "Forward Plus")
 boot_splash/use_filter=false


### PR DESCRIPTION
Made the `!lurk` command use the chatter's username instead of the broadcaster's username.